### PR TITLE
fixes asset.json check

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,12 @@ const staticAsset = arc.static;
 const assetPath = process.env.SHARED_PATH ? `${process.env.SHARED_PATH}/assets.json` : '@architect/shared/assets.json';
 let mapping = false;
 
-if (assetPath.startsWith('@architect')) {
-  mapping = require(assetPath);
-} else if (fs.existsSync(assetPath)) {
-  mapping = require(assetPath);
+if (assetPath.startsWith('@architect') || fs.existsSync(assetPath)) {
+  try {
+    mapping = require(assetPath);
+  } catch (e) {
+    // do nothing
+  }
 }
 
 const routeDir = path.resolve(__dirname, '../../../');

--- a/index.js
+++ b/index.js
@@ -8,9 +8,12 @@ const staticAsset = arc.static;
 const assetPath = process.env.SHARED_PATH ? `${process.env.SHARED_PATH}/assets.json` : '@architect/shared/assets.json';
 let mapping = false;
 
-if (assetPath.startsWith('@architect') || fs.existsSync(assetPath)) {
+if (assetPath.startsWith('@architect')) {
+  mapping = require(assetPath);
+} else if (fs.existsSync(assetPath)) {
   mapping = require(assetPath);
 }
+
 const routeDir = path.resolve(__dirname, '../../../');
 const viewDir = process.env.VIEWS_PATH || path.resolve(routeDir, 'node_modules/@architect/views');
 const nEnv = nunjucks.configure([routeDir, viewDir], { autoescape: true });


### PR DESCRIPTION
If an asset.json resided in the node modules
but didn't actually exist the require would fail.